### PR TITLE
Support migration from unencrypted CN to encrypted CN

### DIFF
--- a/lib/backends/smartos/bin/machine-migrate-receive.js
+++ b/lib/backends/smartos/bin/machine-migrate-receive.js
@@ -132,6 +132,10 @@ function zfsSyncReceive(opts, event, socket) {
         '-s', // If receive is interrupted, save the partially received state.
         '-F', // Rollback to the most recent snapshot before running receive.
               // Brings in any new snapshot names from the source.
+        // Omit the "encryption" property to allow migrating from an unencrypted CN to an encrypted CN
+        // This avoids the following error on the receiving end:
+        //      "zfs receive exited with code: 1 (cannot receive new filesystem stream: parent 'zones' must not be encrypted to receive unenecrypted property)"
+        '-x', 'encryption',
         event.zfsFilesystem
     ];
     var log = opts.log;


### PR DESCRIPTION
When migrating a VM from an unencrypted CN to an encrypted CN the ZFS receive command will fail with the following error if the `encryption` property is not excluded:

```
zfs receive exited with code: 1 (cannot receive new filesystem stream: parent 'zones' must not be encrypted to receive unenecrypted property)
```

It seems like it should be safe to always exclude the `encryption` property even if you're migrating from an encrypted CN to another encrypted CN then the dataset on the receiving end will inherit the property from the `zones` zpool which will be encrypted.